### PR TITLE
Set up CI

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,51 @@
+name: Java CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Set up repository
+        uses: actions/checkout@master
+
+      - name: Set up repository
+        uses: actions/checkout@master
+        with:
+          ref: master
+
+      - name: Merge to master
+        run: git checkout --progress --force ${{ github.sha }}
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+          java-package: jdk+fx
+
+      - name: Build and check with Gradle
+        run: ./gradlew check
+
+#      deprecated
+#      - name: Perform IO redirection test (*NIX)
+#        if: runner.os == 'Linux'
+#        working-directory:  ${{ github.workspace }}/text-ui-test
+#        run: ./runtest.sh
+#
+#      - name: Perform IO redirection test (MacOS)
+#        if: always() && runner.os == 'macOS'
+#        working-directory:  ${{ github.workspace }}/text-ui-test
+#        run: ./runtest.sh
+#
+#      - name: Perform IO redirection test (Windows)
+#        if: always() && runner.os == 'Windows'
+#        working-directory:  ${{ github.workspace }}/text-ui-test
+#        shell: cmd
+#        run: runtest.bat


### PR DESCRIPTION
Use GitHub Actions to set up Continuous Integration (CI).

The workflow specified by this .yml file is a good candidate for this project. The last three segments are related to I/O redirection tests; can be deleted if not applicable to your project.